### PR TITLE
Expand metrics and HTTP API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node-report*
 node_modules
 package-lock.json
 resourceRegistry.log
+coverage/

--- a/lib/appmetrics-prometheus.js
+++ b/lib/appmetrics-prometheus.js
@@ -19,6 +19,7 @@
 const debug = require('debug')('appmetrics-prometheus');
 const util = require('util');
 
+const collections = require('./collections.route');
 
 let envData;
 // Buffer 1 cpu and memory event
@@ -116,6 +117,8 @@ var monitor = function(options) {
 
     var app = express();
 
+    app.use('/appmetrics/api/v1/collections', collections.router);
+
     const url = '/metrics';
     const envMetricsUrl = `${url}/environment`;
     const profilingMetricsUrl = `${url}/profiling`;
@@ -191,6 +194,21 @@ function endpoint(options) {
     res.send(data);
   }
 
+  const collectionsToUpdate = [
+    'cpu',
+    'memory',
+    'gc',
+    'http',
+    'https',
+    'http-outbound',
+  ];
+
+  for (const event of collectionsToUpdate) {
+    monitoring.on(event, (data) => {
+      // console.log(`monitoring.on(${event})`);
+      collections.updateCollections(event, data);
+    });
+  }
 
   monitoring.on('environment', function(data) {
     const thisEnvData = [];

--- a/lib/appmetrics-prometheus.js
+++ b/lib/appmetrics-prometheus.js
@@ -29,12 +29,20 @@ var latestMemEvent = {
   physical: 0,
   virtual: 0
 };
-var aggregateHttpEvent;
+let latestLoopEvent;
+let latestGCEvent;
+let aggregateHttpEvent = {};
+let aggregateHttpsEvent = {};
+let aggregateHttpOutboundEvent = {};
+let aggregateHttpsOutboundEvent = {};
 var httpURLDataList = [];
 var save = {
   http: {},
   https: {},
 };
+// GC summary data
+let gcDurationTotal = 0.0;
+let maxHeapUsed = 0;
 
 
 exports.attach = function(options) {
@@ -79,7 +87,6 @@ exports.attach = function(options) {
 var monitor = function(options) {
   // Protect our options from modification.
   options = util._extend({}, options);
-  var url = '/metrics';
 
   var express = require('express');
   var server;
@@ -100,6 +107,7 @@ var monitor = function(options) {
     server.removeListener('request', listener);
     var app = express();
 
+    const url = '/metrics';
     app.use(url, endpoint(options));
     app.use(url, siteNotFound);
     app.use(url, siteError);
@@ -123,24 +131,39 @@ function endpoint(options) {
   var appmetrics = (options || {}).appmetrics || require('appmetrics');
   var monitoring = appmetrics.monitor();
   function site(req, res) {
-    var cpuData = stringCPUData(latestCPUEvent);
-    var memoryData = stringMemoryData(latestMemEvent);
-    var httpRequestTotal = stringHttpRequestTotal(httpURLDataList);
-    var httpRequestDuration = stringHttpRequestDuration(httpURLDataList);
-    res.writeHead(200, {'Content-Type': 'text/plain'});
-    res.write(cpuData);
-    res.write(memoryData);
-
-    if (httpURLDataList.length > 0) {
-      res.write(httpRequestTotal);
-      res.write(httpRequestDuration);
-    }
-    res.end();
+    const data = [
+      stringCPUData(latestCPUEvent),
+      stringMemoryData(latestMemEvent),
+      stringHttpRequestsAlltimeTotal(httpURLDataList),
+      stringHttpRequestDuration(httpURLDataList),
+      stringProcessUptime(),
+      stringLoopData(),
+      stringGCData(),
+      stringHttpRequestsTotal(),
+      stringHttpRequestsDurationAverage(),
+      stringHttpRequestsDurationMax(),
+      stringHttpsRequestsTotal(),
+      stringHttpsRequestsDurationAverage(),
+      stringHttpsRequestsDurationMax(),
+      stringHttpOutboundRequestsTotal(),
+      stringHttpOutboundRequestsDurationAverage(),
+      stringHttpOutboundRequestsDurationMax(),
+      stringHttpsOutboundRequestsTotal(),
+      stringHttpsOutboundRequestsDurationAverage(),
+      stringHttpsOutboundRequestsDurationMax(),
+      stringHttpRequestsAlltimeDurationAverage(),
+      stringHttpRequestsAlltimeDurationMax(),
+    ].filter(Boolean) // Filters out empty strings
+      .join('\n')
+      .concat('\n'); // Prometheus requires a newline on the end
+    aggregateHttpEvent = {};
+    aggregateHttpsEvent = {};
+    aggregateHttpOutboundEvent = {};
+    aggregateHttpsOutboundEvent = {};
+    res.send(data);
   }
 
-  /*
-   * Broadcast monitoring data to connected clients when it arrives
-   */
+
   monitoring.on('cpu', function(data) {
     latestCPUEvent = data;
   });
@@ -149,53 +172,22 @@ function endpoint(options) {
     latestMemEvent = data;
   });
 
-  monitoring.on('http', function(data) {
-    if (!aggregateHttpEvent) {
-      aggregateHttpEvent = {};
-      aggregateHttpEvent.total = 1;
-      aggregateHttpEvent.average = data.duration;
-      aggregateHttpEvent.longest = data.duration;
-      aggregateHttpEvent.time = data.time;
-      aggregateHttpEvent.handler = data.url;
-      aggregateHttpEvent.code = data.statusCode;
-      aggregateHttpEvent.method = data.method;
-    } else {
-      aggregateHttpEvent.total = aggregateHttpEvent.total + 1;
-      aggregateHttpEvent.average = (aggregateHttpEvent.average * (aggregateHttpEvent.total - 1) + data.duration) / aggregateHttpEvent.total;
-      if (data.duration > aggregateHttpEvent.longest) {
-        aggregateHttpEvent.longest = data.duration;
-        aggregateHttpEvent.url = data.url;
-      }
-    }
-
-    // See if httpURLDataList contains a json object which has already has the collected url and statusCode
-    var found = false;
-    var foundIndex;
-    var i = 0;
-    while (found === false && i < httpURLDataList.length) {
-      if (httpURLDataList[i].url == data.url && httpURLDataList[i].code == data.statusCode) {
-        found = true;
-        foundIndex = i;
-      }
-      i++;
-    }
-
-    // If found we increment the number of hits on the url
-    // Else add new json object to list with the 'hits' value of 1
-    if (found) {
-      var urlData = httpURLDataList[foundIndex];
-      // Recalculate the average
-      urlData.average_duration = (urlData.duration * urlData.hits + data.duration) / (urlData.hits + 1);
-      urlData.hits = urlData.hits + 1;
-      // Add new duration to the duration_list
-      urlData.duration_list.push(data.duration);
-      // Reorder duration_list so it is in ascending order
-      urlData.duration_list.sort(function(a, b){ return a - b; });
-    } else {
-      httpURLDataList.push({url: data.url, average_duration: data.duration, hits: 1, method: data.method, code: data.statusCode, duration_list: [data.duration]});
-    }
-
+  monitoring.on('loop', function(data) {
+    latestLoopEvent = data;
   });
+  monitoring.on('gc', function(data) {
+    latestGCEvent = data;
+    gcDurationTotal += data.duration;
+    maxHeapUsed = Math.max(maxHeapUsed, data.used);
+    latestGCEvent.timeSummary = (gcDurationTotal / (process.uptime() * 1000));
+    latestGCEvent.usedHeapAfterGCMax = maxHeapUsed;
+  });
+
+  monitoring.on('http', (data) => saveHttpOrHttpsData(data, aggregateHttpEvent, httpURLDataList));
+  monitoring.on('https', (data) => saveHttpOrHttpsData(data, aggregateHttpsEvent, httpURLDataList));
+  monitoring.on('http-outbound', (data) => updateAggregateEvent(aggregateHttpOutboundEvent, data));
+  monitoring.on('https-outbound', (data) => updateAggregateEvent(aggregateHttpsOutboundEvent, data));
+
   return site;
 }
 
@@ -219,7 +211,7 @@ function stringCPUData(latestCPUEvent) {
   content += 'os_cpu_used_ratio ' + latestCPUEvent.system + '\n';
   content += '# HELP process_cpu_used_ratio The ratio of the process CPU that is currently used (values are 0-1)\n';
   content += '# TYPE process_cpu_used_ratio gauge\n';
-  content += 'process_cpu_used_ratio ' + latestCPUEvent.process + '\n';
+  content += 'process_cpu_used_ratio ' + latestCPUEvent.process;
   return content;
 }
 
@@ -233,25 +225,21 @@ function stringMemoryData(latestMemEvent) {
   content += 'process_resident_memory_bytes ' + latestMemEvent.physical + '\n';
   content += '# HELP process_virtual_memory_bytes Virtual memory size in bytes.\n';
   content += '# TYPE process_virtual_memory_bytes gauge\n';
-  content += 'process_virtual_memory_bytes ' + latestMemEvent.virtual + '\n';
+  content += 'process_virtual_memory_bytes ' + latestMemEvent.virtual;
   return content;
 }
 
-function stringHttpRequestTotal(httpURLDataList) {
-  var content = '';
-  content += '# HELP http_requests_total Total number of HTTP requests made.\n';
-  content += '# TYPE http_requests_total counter\n';
-  // Loop through httpURLDataList to display the appmetrics_http_requests_total
-  for (var i = 0; i < httpURLDataList.length; i++) {
-    var data = httpURLDataList[i];
-    // Convert the method to lowercase as per Prometheus guidelines (Appmetrics gives us method in uppercase)
-    var lowerCaseMethod = data.method.toLowerCase();
-    content += 'http_requests_total{code="' + data.code + '", handler="' + data.url +
-      '", method="' + lowerCaseMethod + '"} ' + data.hits + '\n';
+function stringHttpRequestsAlltimeTotal(httpURLDataList) {
+  if (!httpURLDataList.length) return;
+  return [
+    // i.e. Total number of HTTP requests received by this app since it started
+    '# HELP http_requests_total Total number of HTTP requests made.',
+    '# TYPE http_requests_total counter',
+    ...httpURLDataList.map(data =>
+      `http_requests_total{code="${data.code}", handler="${data.url}", method="${data.method.toLowerCase()}"} ${data.hits}`
+    ),
+  ].join('\n');
   }
-  return content;
-}
-
 function stringHttpRequestDuration(httpURLDataList) {
   var content = '';
   content += '# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.\n';
@@ -268,9 +256,267 @@ function stringHttpRequestDuration(httpURLDataList) {
     content += 'http_request_duration_microseconds{handler="' + data.url + '",quantile="0.9"} ' + quantileNinety + '\n';
     content += 'http_request_duration_microseconds{handler="' + data.url + '",quantile="0.99"} ' + quantileNinetyNine + '\n';
     content += 'http_request_duration_microseconds_sum{handler="' + data.url + '"} ' + sumDurations + '\n';
-    content += 'http_request_duration_microseconds_count{handler="' + data.url + '"} ' + countDurations + '\n';
+    content += 'http_request_duration_microseconds_count{handler="' + data.url + '"} ' + countDurations;
   }
   return content;
+}
+
+function stringProcessUptime() {
+  return [
+    '# HELP process_uptime_count_seconds The number of seconds for which the current Node.js process has been running',
+    '# TYPE process_uptime_count_seconds counter',
+    `process_uptime_count_seconds ${process.uptime()}`,
+  ];
+}
+
+function stringLoopData() {
+  if (!latestLoopEvent) return;
+  return [
+    '# HELP event_loop_tick_min_milliseconds The shortest tick time in the event loop samples, in milliseconds',
+    '# TYPE event_loop_tick_min_milliseconds guage',
+    `event_loop_tick_min_milliseconds ${latestLoopEvent.minimum}`,
+
+    '# HELP event_loop_tick_max_milliseconds The longest tick time in the event loop samples, in milliseconds',
+    '# TYPE event_loop_tick_max_milliseconds guage',
+    `event_loop_tick_max_milliseconds ${latestLoopEvent.maximum}`,
+
+    '# HELP event_loop_tick_count The number of event loop ticks in the last interval',
+    '# TYPE event_loop_tick_count counter',
+    `event_loop_tick_count ${latestLoopEvent.count}`,
+
+    '# HELP event_loop_tick_average_milliseconds The average tick time in the event loop samples, in milliseconds',
+    '# TYPE event_loop_tick_average_milliseconds guage',
+    `event_loop_tick_average_milliseconds ${latestLoopEvent.average}`,
+
+    '# HELP event_loop_cpu_user The percentage of 1 CPU used by the event loop thread in user code the last interval. This is a value between 0.0 and 1.0.',
+    '# TYPE event_loop_cpu_user guage',
+    `event_loop_cpu_user ${latestLoopEvent.cpu_user}`,
+
+    '# HELP event_loop_cpu_system The percentage of 1 CPU used by the event loop thread in system code in the last interval. This is a value between 0.0 and 1.0.',
+    '# TYPE event_loop_cpu_system guage',
+    `event_loop_cpu_system ${latestLoopEvent.cpu_system}`,
+  ].join('\n');
+}
+
+function stringGCData() {
+  if (!latestGCEvent) return;
+  return [
+    '# HELP heap_size_bytes The size of the JavaScript heap in bytes',
+    '# TYPE heap_size_bytes guage',
+    `heap_size_bytes ${latestGCEvent.size}`,
+
+    '# HELP heap_memory_used_bytes The amount of memory used on the JavaScript heap in bytes',
+    '# TYPE heap_memory_used_bytes guage',
+    `heap_memory_used_bytes ${latestGCEvent.used}`,
+
+    '# HELP heap_memory_used_max_bytes The maximum amount of memory used on the JavaScript heap in bytes',
+    '# TYPE heap_memory_used_max_bytes count',
+    `heap_memory_used_max_bytes ${maxHeapUsed}`,
+
+    '# HELP gc_cycle_duration_milliseconds The duration of the GC cycle in milliseconds',
+    '# TYPE gc_cycle_duration_milliseconds guage',
+    `gc_cycle_duration_milliseconds ${latestGCEvent.duration}`,
+
+    '# HELP gc_cycle_duration_total_milliseconds The total duration of all GC cycles in milliseconds',
+    '# TYPE gc_cycle_duration_total_milliseconds count',
+    `gc_cycle_duration_total_milliseconds ${gcDurationTotal}`,
+  ].join('\n');
+}
+
+function stringHttpRequestsTotal() {
+  if (isEmptyObject(aggregateHttpEvent)) return;
+  return [
+    '# HELP http_requests_snapshot_total Total number of HTTP requests received in this snapshot.',
+    '# TYPE http_requests_snapshot_total guage',
+    `http_requests_snapshot_total ${aggregateHttpEvent.total}`,
+  ].join('\n');
+}
+
+function stringHttpRequestsDurationAverage() {
+  if (isEmptyObject(aggregateHttpEvent)) return;
+  return [
+    '# HELP http_requests_duration_average_microseconds Average duration of HTTP requests received in this snapshot.',
+    '# TYPE http_requests_duration_average_microseconds guage',
+    `http_requests_duration_average_microseconds ${aggregateHttpEvent.average}`,
+  ].join('\n');
+}
+
+function stringHttpRequestsDurationMax() {
+  if (isEmptyObject(aggregateHttpEvent)) return;
+  return [
+    '# HELP http_requests_duration_max_microseconds Longest HTTP request received in this snapshot.',
+    '# TYPE http_requests_duration_max_microseconds guage',
+    `http_requests_duration_max_microseconds{handler="${aggregateHttpEvent.url}"} ${aggregateHttpEvent.longest}`,
+  ].join('\n');
+}
+
+function stringHttpsRequestsTotal() {
+  if (isEmptyObject(aggregateHttpsEvent)) return;
+  return [
+    '# HELP https_requests_total Total number of HTTPS requests received in this snapshot.',
+    '# TYPE https_requests_total guage',
+    `https_requests_total ${aggregateHttpsEvent.total}`,
+  ].join('\n');
+}
+
+function stringHttpsRequestsDurationAverage() {
+  if (isEmptyObject(aggregateHttpsEvent)) return;
+  return [
+    '# HELP https_requests_duration_average_microseconds Average duration of HTTPS requests received in this snapshot.',
+    '# TYPE https_requests_duration_average_microseconds guage',
+    `https_requests_duration_average_microseconds ${aggregateHttpsEvent.average}`,
+  ].join('\n');
+}
+
+function stringHttpsRequestsDurationMax() {
+  if (isEmptyObject(aggregateHttpsEvent)) return;
+  return [
+    '# HELP https_requests_duration_max_microseconds Longest HTTPS request received in this snapshot.',
+    '# TYPE https_requests_duration_max_microseconds guage',
+    `https_requests_duration_max_microseconds{handler="${aggregateHttpsEvent.url}"} ${aggregateHttpsEvent.longest}`,
+  ].join('\n');
+}
+
+function stringHttpOutboundRequestsTotal() {
+  if (isEmptyObject(aggregateHttpOutboundEvent)) return;
+  return [
+    '# HELP http_outbound_requests_total Total number of HTTP requests sent during this snapshot.',
+    '# TYPE http_outbound_requests_total guage',
+    `http_outbound_requests_total ${aggregateHttpOutboundEvent.total}`,
+  ].join('\n');
+}
+
+function stringHttpOutboundRequestsDurationAverage() {
+  if (isEmptyObject(aggregateHttpOutboundEvent)) return;
+  return [
+    '# HELP http_outbound_requests_duration_average_microseconds Average duration of HTTP requests sent during this snapshot.',
+    '# TYPE http_outbound_requests_duration_average_microseconds guage',
+    `http_outbound_requests_duration_average_microseconds ${aggregateHttpOutboundEvent.average}`,
+  ].join('\n');
+}
+
+function stringHttpOutboundRequestsDurationMax() {
+  if (isEmptyObject(aggregateHttpOutboundEvent)) return;
+  return [
+    '# HELP http_outbound_requests_duration_max_microseconds Longest HTTP request sent during this snapshot.',
+    '# TYPE http_outbound_requests_duration_max_microseconds guage',
+    `http_outbound_requests_duration_max_microseconds{url="${aggregateHttpOutboundEvent.url}"} ${aggregateHttpOutboundEvent.longest}`,
+  ].join('\n');
+}
+
+function stringHttpsOutboundRequestsTotal() {
+  if (isEmptyObject(aggregateHttpsOutboundEvent)) return;
+  return [
+    '# HELP https_outbound_requests_total Total number of HTTPS requests sent during this snapshot.',
+    '# TYPE https_outbound_requests_total guage',
+    `https_outbound_requests_total ${aggregateHttpsOutboundEvent.total}`,
+  ].join('\n');
+}
+
+function stringHttpsOutboundRequestsDurationAverage() {
+  if (isEmptyObject(aggregateHttpsOutboundEvent)) return;
+  return [
+    '# HELP https_outbound_requests_duration_average_microseconds Average duration of HTTPS requests sent during this snapshot.',
+    '# TYPE https_outbound_requests_duration_average_microseconds guage',
+    `https_outbound_requests_duration_average_microseconds ${aggregateHttpsOutboundEvent.average}`,
+  ].join('\n');
+}
+
+function stringHttpsOutboundRequestsDurationMax() {
+  if (isEmptyObject(aggregateHttpsOutboundEvent)) return;
+  return [
+    '# HELP https_outbound_requests_duration_max_microseconds Longest HTTPS request sent during this snapshot.',
+    '# TYPE https_outbound_requests_duration_max_microseconds guage',
+    `https_outbound_requests_duration_max_microseconds{url="${aggregateHttpsOutboundEvent.url}"} ${aggregateHttpsOutboundEvent.longest}`,
+  ].join('\n');
+}
+
+function stringHttpRequestsAlltimeDurationAverage() {
+  if (!httpURLDataList.length) return;
+  return [
+    '# HELP http_requests_alltime_duration_average_microseconds Average duration of HTTP requests received since app started.',
+    '# TYPE http_requests_alltime_duration_average_microseconds guage',
+    ...httpURLDataList.map(data =>
+      `http_requests_alltime_duration_average_microseconds{handler="${data.url}",method="${data.method.toLowerCase()}"} ${data.average_duration}`
+    ),
+  ].join('\n');
+}
+
+function stringHttpRequestsAlltimeDurationMax() {
+  if (!httpURLDataList.length) return;
+  return [
+    '# HELP http_requests_alltime_duration_max_microseconds Average duration of HTTP requests received since app started.',
+    '# TYPE http_requests_alltime_duration_max_microseconds guage',
+    ...httpURLDataList.map(data =>
+      `http_requests_alltime_duration_max_microseconds{handler="${data.url}",method="${data.method.toLowerCase()}"} ${data.longest_duration}`
+    ),
+  ].join('\n');
+}
+
+function saveHttpOrHttpsData(data, aggregateEvent, httpURLDataList) {
+  updateAggregateEvent(aggregateEvent, data);
+  updateHttpURLDataList(httpURLDataList, data);
+}
+
+function updateAggregateEvent(event, data) {
+  if (isEmptyObject(event)) {
+    event.total = 1;
+    event.average = data.duration;
+    event.longest = data.duration;
+    event.time = data.time;
+    event.url = data.url;
+    event.code = data.statusCode;
+    event.method = data.method;
+  } else {
+    event.total = event.total + 1;
+    event.average = (event.average * (event.total - 1) + data.duration) / event.total;
+    if (data.duration > event.longest) {
+      event.longest = data.duration;
+      event.url = data.url;
+    }
+  }
+}
+
+function updateHttpURLDataList(URLDataList, data) {
+  // See if httpURLDataList contains a json object which has already has the collected url and statusCode
+  var found = false;
+  var foundIndex;
+  var i = 0;
+  while (found === false && i < URLDataList.length) {
+    if (URLDataList[i].url == data.url && URLDataList[i].code == data.statusCode) {
+      found = true;
+      foundIndex = i;
+    }
+    i++;
+  }
+
+  // If found we increment the number of hits on the url
+  // Else add new json object to URLDataList with the 'hits' value of 1
+  if (found) {
+    var urlData = URLDataList[foundIndex];
+    // Recalculate the average
+    urlData.average_duration = (urlData.average_duration * urlData.hits + data.duration) / (urlData.hits + 1);
+    urlData.hits = urlData.hits + 1;
+    // Add new duration to the duration_list
+    urlData.duration_list.push(data.duration);
+    urlData.longest_duration = Math.max(...urlData.duration_list);
+    // Reorder duration_list so it is in ascending order
+    urlData.duration_list.sort(function(a, b){ return a - b; });
+  } else {
+    URLDataList.push({
+      url: data.url,
+      average_duration: data.duration,
+      longest_duration: data.duration,
+      hits: 1,
+      method: data.method,
+      code: data.statusCode,
+      duration_list: [data.duration]
+    });
+  }
+}
+
+function isEmptyObject(obj) {
+  return !Object.keys(obj).length;
 }
 
 function findQuantile(list, quantile) {

--- a/lib/appmetrics-prometheus.js
+++ b/lib/appmetrics-prometheus.js
@@ -317,7 +317,8 @@ function stringHttpRequestsAlltimeTotal(httpURLDataList) {
       `http_requests_total{code="${data.code}", handler="${data.url}", method="${data.method.toLowerCase()}"} ${data.hits}`
     ),
   ].join('\n');
-  }
+}
+
 function stringHttpRequestDuration(httpURLDataList) {
   var content = '';
   content += '# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.\n';

--- a/lib/appmetrics-prometheus.js
+++ b/lib/appmetrics-prometheus.js
@@ -36,6 +36,7 @@ let aggregateHttpsEvent = {};
 let aggregateHttpOutboundEvent = {};
 let aggregateHttpsOutboundEvent = {};
 var httpURLDataList = [];
+let profilingSamples = [];
 var save = {
   http: {},
   https: {},
@@ -105,9 +106,30 @@ var monitor = function(options) {
   function patch(listener) {
     debug('patching %s', listener);
     server.removeListener('request', listener);
+
+    // appmetrics is a global singleton, allow the user's appmetrics to be
+    // injected, only using our own if the user did not supply one.
+    var appmetrics = options.appmetrics || require('appmetrics');
+    var monitoring = appmetrics.monitor();
+
     var app = express();
 
     const url = '/metrics';
+    const profilingMetricsUrl = `${url}/profiling`;
+    const enableProfilingMetricsUrl = `${profilingMetricsUrl}/on`;
+    const disableProfilingMetricsUrl = `${profilingMetricsUrl}/off`;
+
+    app.use(enableProfilingMetricsUrl, (req, res) => {
+      monitoring.enable('profiling');
+      res.send('Profiling enabled');
+    });
+    app.use(disableProfilingMetricsUrl, (req, res) => {
+      monitoring.disable('profiling');
+      res.send('Profiling disabled');
+    });
+    app.use(profilingMetricsUrl, (req, res) => {
+      res.send(profilingSamples);
+    });
     app.use(url, endpoint(options));
     app.use(url, siteNotFound);
     app.use(url, siteError);
@@ -163,6 +185,10 @@ function endpoint(options) {
     res.send(data);
   }
 
+
+  monitoring.on('profiling', (profilingSample) => {
+    profilingSamples.push(profilingSample);
+  });
 
   monitoring.on('cpu', function(data) {
     latestCPUEvent = data;

--- a/lib/appmetrics-prometheus.js
+++ b/lib/appmetrics-prometheus.js
@@ -19,6 +19,8 @@
 const debug = require('debug')('appmetrics-prometheus');
 const util = require('util');
 
+
+let envData;
 // Buffer 1 cpu and memory event
 var latestCPUEvent = {
   process: 0,
@@ -115,6 +117,7 @@ var monitor = function(options) {
     var app = express();
 
     const url = '/metrics';
+    const envMetricsUrl = `${url}/environment`;
     const profilingMetricsUrl = `${url}/profiling`;
     const enableProfilingMetricsUrl = `${profilingMetricsUrl}/on`;
     const disableProfilingMetricsUrl = `${profilingMetricsUrl}/off`;
@@ -129,6 +132,9 @@ var monitor = function(options) {
     });
     app.use(profilingMetricsUrl, (req, res) => {
       res.send(profilingSamples);
+    });
+    app.use(envMetricsUrl, (req, res) => {
+      res.send(envData);
     });
     app.use(url, endpoint(options));
     app.use(url, siteNotFound);
@@ -185,6 +191,34 @@ function endpoint(options) {
     res.send(data);
   }
 
+
+  monitoring.on('environment', function(data) {
+    const thisEnvData = [];
+    for (const [Key, Value] of Object.entries(data)) {
+      if (Key === 'command.line') {
+        thisEnvData.push({
+          Parameter: 'Command Line',
+          Value,
+        });
+      } else if (Key === 'environment.HOSTNAME') {
+        thisEnvData.push({
+          Parameter: 'Hostname',
+          Value,
+        });
+      } else if (Key === 'os.arch') {
+        thisEnvData.push({
+          Parameter: 'OS Architecture',
+          Value,
+        });
+      } else if (Key === 'number.of.processors') {
+        thisEnvData.push({
+          Parameter: 'Number of Processors',
+          Value,
+        });
+      }
+    }
+    envData = thisEnvData;
+  });
 
   monitoring.on('profiling', (profilingSample) => {
     profilingSamples.push(profilingSample);

--- a/lib/classes/collections.js
+++ b/lib/classes/collections.js
@@ -1,0 +1,209 @@
+/*******************************************************************************
+ * Copyright 2018 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+'use strict';
+let instanceId = 0;
+
+var Collections = class Collections {
+
+  constructor() {
+    this.collection = {
+      id: instanceId,
+      time: {
+        data: {
+          start: new Date().getTime(),
+          end: new Date().getTime()
+        },
+        units: {
+          start: 'UNIX time (ms)',
+          end: 'UNIX time (ms)'
+        }
+      },
+      cpu: {
+        data: {
+          systemMean: 0,
+          systemPeak: 0,
+          processMean: 0,
+          processPeak: 0
+        },
+        units: {
+          systemMean: 'decimal fraction',
+          systemPeak: 'decimal fraction',
+          processMean: 'decimal fraction',
+          processPeak: 'decimal fraction'
+        }
+      },
+      gc: {
+        data: {
+          gcTime: 0
+        },
+        units: {
+          gcTime: 'decimal fraction'
+        }
+      },
+      memory: {
+        data: {
+          usedHeapAfterGCPeak: 0,
+          usedNativePeak: 0
+        },
+        units: {
+          usedHeapAfterGCPeak: 'bytes',
+          usedNativePeak: 'bytes'
+        }
+      },
+      httpUrls: {
+        data: [],
+        units: {
+          averageResponseTime: 'ms',
+          longestResponseTime: 'ms',
+          hits: 'count'
+        }
+      }
+    };
+    this.cpuLoadSamples = 0;
+    this.totalSystemCPULoad = 0.0;
+    this.totalProcessCPULoad = 0.0;
+    this.gcDurationTotal = 0.0;
+    this.maxHeapUsed = 0;
+    this.usedNativePeak = 0;
+    this.httpURLData = {};
+    // increment instance ID for next time
+    instanceId += 1;
+  }
+
+  cpu(data) {
+    // If new CPU data is greater than the current update the peak
+    if (this.collection.cpu.data.processPeak < data.process) {
+      this.collection.cpu.data.processPeak = data.process;
+    }
+
+    if (this.collection.cpu.data.systemPeak < data.system) {
+      this.collection.cpu.data.systemPeak = data.system;
+    }
+    // Update the totals for use with average
+    this.totalSystemCPULoad += data.system;
+    this.totalProcessCPULoad += data.process;
+    this.cpuLoadSamples++;
+    this.collection.cpu.data.systemMean = (this.totalSystemCPULoad / this.cpuLoadSamples);
+    this.collection.cpu.data.processMean = (this.totalProcessCPULoad / this.cpuLoadSamples);
+  }
+
+
+  memory(data) {
+    // If new physical_used is bigger than the peak, update
+    if (this.usedNativePeak < data.physical_used) {
+      this.usedNativePeak = data.physical_used;
+    }
+    this.collection.memory.data.usedNativePeak = this.usedNativePeak;
+  }
+
+  gc(data) {
+    this.gcDurationTotal += data.duration;
+    this.maxHeapUsed = Math.max(this.maxHeapUsed, data.used);
+    let timeSummary = (this.gcDurationTotal / (process.uptime() * 1000));
+    // The used heap should be under memory
+    this.collection.memory.data.usedHeapAfterGCPeak = this.maxHeapUsed;
+    // Update GC time summary
+    this.collection.gc.data = {gcTime: timeSummary};
+  }
+
+  http(data) {
+    let list = this.collection.httpUrls.data;
+    let placeInList = -1;
+    for (let i = 0; i < list.length; i++) {
+      if (list[i].url === data.url && list[i].method === data.method) {
+        placeInList = i;
+      }
+    }
+    if (placeInList != -1) {
+      // Recalculate the average
+      let urlData = this.collection.httpUrls.data[placeInList];
+      urlData.averageResponseTime = (urlData.averageResponseTime * urlData.hits + data.duration) / (urlData.hits + 1);
+      urlData.hits = urlData.hits + 1;
+      if (data.duration > urlData.longestResponseTime) {
+        urlData.longestResponseTime = data.duration;
+      }
+    } else {
+      let urlJSON = { url: data.url, method: data.method, hits: 1, averageResponseTime: data.duration, longestResponseTime: data.duration };
+      this.collection.httpUrls.data.push(urlJSON);
+    }
+  }
+
+  reset() {
+    this.collection = {
+      id: this.collection.id,
+      time: {
+        data: {
+          start: new Date().getTime(),
+          end: new Date().getTime()
+        },
+        units: {
+          start: 'UNIX time (ms)',
+          end: 'UNIX time (ms)'
+        }
+      },
+      cpu: {
+        data: {
+          systemMean: 0,
+          systemPeak: 0,
+          processMean: 0,
+          processPeak: 0
+        },
+        units: {
+          systemMean: 'decimal fraction',
+          systemPeak: 'decimal fraction',
+          processMean: 'decimal fraction',
+          processPeak: 'decimal fraction'
+        }
+      },
+      gc: {
+        data: {
+          gcTime: 0
+        },
+        units: {
+          gcTime: 'decimal fraction'
+        }
+      },
+      memory: {
+        data: {
+          usedHeapAfterGCPeak: 0,
+          usedNativePeak: 0
+        },
+        units: {
+          usedHeapAfterGCPeak: 'bytes',
+          usedNativePeak: 'bytes'
+        }
+      },
+      httpUrls: {
+        data: [],
+        units: {
+          averageResponseTime: 'ms',
+          longestResponseTime: 'ms',
+          hits: 'count'
+        }
+      }
+    };
+    this.cpuLoadSamples = 0;
+    this.totalSystemCPULoad = 0.0;
+    this.totalProcessCPULoad = 0.0;
+    this.gcDurationTotal = 0.0;
+    this.maxHeapUsed = 0;
+    this.usedNativePeak = 0;
+    this.httpURLData = {};
+  }
+
+};
+
+module.exports = Collections;

--- a/lib/collections.route.js
+++ b/lib/collections.route.js
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright 2018 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+'use strict';
+
+const express = require('express');
+
+const Collection = require('./classes/collections');
+
+const router = express.Router();
+let collections = [];
+
+/**
+ * Routes
+ * GET      /appmetrics/api/v1/collections         - get an array of all collections available
+ * GET      /appmetrics/api/v1/collections/:id     - returns a given collection
+ * PUT      /appmetrics/api/v1/collections/:id     - zero all values in a collection, returns the collection before resetting the values
+ * DELETE   /appmetrics/api/v1/collections/:id     - delete a single collection, returns the collection before state before deletion
+ * POST     /appmetrics/api/v1/collections         - creates a new collection and returns it
+ */
+
+router.get('/', function(req, res) {
+  let json = { collectionUris: [] };
+  for (const collection of collections) {
+    let string = 'collections/' + collection.collection.id;
+    json.collectionUris.push(string);
+  }
+  res.status(200).json(json);
+});
+
+router.get('/:id', function(req, res) {
+  getCollection(req, res, function(i) {
+    res.status(200).json(collections[i].collection);
+  });
+});
+
+router.put('/:id', function(req, res) {
+  getCollection(req, res, function(i) {
+    collections[i].reset();
+    res.sendStatus(204);
+  });
+});
+
+router.delete('/:id', function(req, res) {
+  getCollection(req, res, function(i) {
+    collections.splice(i, 1);
+    res.sendStatus(204);
+  });
+});
+
+router.post('', function(req, res) {
+  let col = new Collection();
+  collections.push(col);
+  res.status(201);
+  let colUrl = 'collections/' + col.collection.id;
+  res.header('Location', colUrl);
+  let json = {};
+  json.uri = colUrl;
+  res.json(json);
+});
+
+/**
+ * Function to send a collection to the user using the API Will either return a
+ * 200 code if successful or a 400 if not
+ *
+ * @param req,
+ *            the request from the API call
+ * @param res,
+ *            the response for the API call
+ * @param cb,
+ *            a callback function, called if the API call is successful
+ */
+function getCollection(req, res, cb) {
+  let id = req.params.id;
+  let index = -1;
+  // Don't assume that the list will match up to ids
+  for (var i = 0; i < collections.length; i++) {
+    if (collections[i].collection.id == id) {
+      index = i;
+    }
+  }
+  if (index != -1) {
+    try {
+      let col = collections[index].collection;
+      col.time.data.end = new Date().getTime();
+      if (cb) {
+        cb(index);
+      }
+    } catch (err) {
+      res.status(204);
+      res.send('Requested collection cannot be accessed');
+    }
+  } else {
+    res.status(404).end();
+  }
+}
+
+function updateCollections(type, data) {
+  for (const collection of collections) {
+    switch (type) {
+      case 'cpu':
+        collection.cpu(data);
+        break;
+      case 'memory':
+        collection.memory(data);
+        break;
+      case 'gc':
+        collection.gc(data);
+        break;
+      case 'http':
+      case 'https':
+        collection.http(data);
+        break;
+      default:
+        break;
+    }
+  }
+};
+
+module.exports = {
+  router,
+  updateCollections,
+};

--- a/test/apps/createHttpServer.js
+++ b/test/apps/createHttpServer.js
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright 2017 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+'use strict';
+
+const http = require('http');
+
+function createHttpServer() {
+  const server = http.createServer();
+
+  server.listen(0, 'localhost', function() {
+    const { address, port } = this.address();
+    console.log(`listening on ${address}:${port}`);
+  });
+
+  server.on('request', function(req, res) {
+    res.write('This is the app!');
+    res.end();
+  });
+
+  return server;
+}
+
+
+module.exports = createHttpServer;

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright 2017 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+'use strict';
+
+const expectedMetrics = [
+  'os_cpu_used_ratio',
+  'process_cpu_used_ratio',
+  'os_resident_memory_bytes',
+  'process_resident_memory_bytes',
+  'process_virtual_memory_bytes',
+  'http_request_duration_microseconds',
+  'process_uptime_count_seconds',
+  // Other metrics not immediately available:
+  // 'http_requests_total',
+  // 'event_loop_tick_min_milliseconds',
+  // 'event_loop_tick_max_milliseconds',
+  // 'event_loop_tick_average_milliseconds',
+  // 'event_loop_cpu_user',
+  // 'event_loop_cpu_system',
+  // 'heap_size_bytes',
+  // 'heap_memory_used_bytes',
+  // 'heap_memory_used_max_bytes',
+  // 'gc_cycle_duration_milliseconds',
+  // 'gc_cycle_duration_total_milliseconds',
+  // 'http_requests_snapshot_total',
+  // 'http_requests_duration_average_microseconds',
+  // 'http_requests_duration_max_microseconds',
+  // 'http_requests_alltime_duration_average_microseconds',
+];
+
+module.exports = {
+  expectedMetrics,
+};

--- a/test/test-collections-routes.js
+++ b/test/test-collections-routes.js
@@ -1,0 +1,240 @@
+/*******************************************************************************
+ * Copyright 2018 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+'use strict';
+
+// Test framework.
+const debug = require('debug')('collections.route.js:test');
+const request = require('request');
+const tap = require('tap');
+const util = require('util');
+
+const createHttpServer = require('./apps/createHttpServer');
+
+const expectedReponseToGetCollectionId = {
+  id: 0,
+  time: {
+    data: {
+      start: /[0-9999999999999]/,
+      end: /[0-9999999999999]/,
+    },
+    units: {
+      start: 'UNIX time',
+      end: 'UNIX time',
+    }
+  },
+  cpu: {
+    data: {
+      systemMean: 0,
+      systemPeak: 0,
+      processMean: 0,
+      processPeak: 0
+    },
+    units: {
+      systemMean: 'decimal fraction',
+      systemPeak: 'decimal fraction',
+      processMean: 'decimal fraction',
+      processPeak: 'decimal fraction'
+    }
+  },
+  gc: {
+    data: {
+      gcTime: 0
+    },
+    units: {
+      gcTime: 'decimal fraction'
+    }
+  },
+  memory: {
+    data: {
+      usedHeapAfterGCPeak: 0,
+      usedNativePeak: 0
+    },
+    units: {
+      usedHeapAfterGCPeak: 'bytes',
+      usedNativePeak: 'bytes'
+    }
+  },
+  httpUrls: []
+};
+
+// Setup appmetrics and start app somewhat as a supervisor would.
+const appmetrics = require('appmetrics');
+appmetrics.start();
+require('..').attach({appmetrics: appmetrics});
+
+const server = createHttpServer();
+
+let base;
+
+tap.test('start', function(t) {
+  server.on('listening', function() {
+    const port = this.address().port;
+    let addr = this.address().address;
+    if (addr === '0.0.0.0')
+      addr = '127.0.0.1';
+    if (addr === '::')
+      addr = '[::1]';
+    base = util.format('http://%s:%s', addr, port);
+    t.pass('listened');
+    t.end();
+  });
+});
+
+// Test for empty collections object
+tap.test('GET collections', function(t) {
+  const options = {
+    url: base + '/appmetrics/api/v1/collections',
+    method: 'GET'
+  };
+  debug('request %j', options);
+  request(options, function(err, res, body) {
+    t.ifError(err);
+    t.equal(body, '{"collectionUris":[]}');
+    t.end();
+  });
+});
+
+// Test for collection creation
+tap.test('POST collections', function(t) {
+  const options = {
+    url: base + '/appmetrics/api/v1/collections',
+    method: 'POST'
+  };
+  debug('request %j', options);
+  request(options, function(err, res, body) {
+    t.ifError(err);
+    t.equal(res.statusCode, 201);
+    t.equal(body, '{"uri":"collections/0"}');
+    t.end();
+  });
+});
+
+// Test to check a GET request on a given collection
+tap.test('GET single collection', function(t) {
+  const options = {
+    url: base + '/appmetrics/api/v1/collections/0',
+    method: 'GET'
+  };
+  debug('request %j', options);
+  request(options, function(err, res, body) {
+    t.ifError(err);
+    let expectedResponse = expectedReponseToGetCollectionId;
+    let json = JSON.parse(body);
+    t.similar(json, expectedResponse);
+    t.equal(json.id, 0);
+    t.equal(res.statusCode, 200);
+    t.end();
+  });
+});
+
+// Test to make a PUT request on a given collection
+tap.test('PUT collection', function(t) {
+  const options = {
+    url: base + '/appmetrics/api/v1/collections/0',
+    method: 'PUT'
+  };
+  debug('request %j', options);
+  request(options, function(err, res) {
+    t.ifError(err);
+    t.equal(res.statusCode, 204);
+    t.end();
+  });
+});
+
+// Test to check the list of collections after another collection has been added
+tap.test('GET collections (more than one)', function(t) {
+  const options = {
+    url: base + '/appmetrics/api/v1/collections',
+    method: 'GET'
+  };
+  // Create another collection
+  request({url: options.url, method: 'POST' }, function(err) {
+    if (err) {
+      console.err('Error creating another collection');
+    }
+    t.ifError(err);
+  });
+  debug('request %j', options);
+  request(options, function(err, res, body) {
+    t.ifError(err);
+    let expectedResponse = '{"collectionUris":["collections/0","collections/1"]}';
+    t.equal(body, expectedResponse);
+    t.equal(res.statusCode, 200);
+    t.end();
+  });
+});
+
+// Test to DELETE a given collection
+tap.test('DELETE collection', function(t) {
+  const options = {
+    url: base + '/appmetrics/api/v1/collections/0',
+    method: 'DELETE'
+  };
+  debug('request %j', options);
+  request(options, function(err, res) {
+    t.ifError(err);
+    t.equal(res.statusCode, 204);
+    t.end();
+  });
+});
+
+// Test to attempt to retrieve a given collection
+tap.test('GET deleted collection', function(t) {
+  const options = {
+    url: base + '/appmetrics/api/v1/collections/0',
+    method: 'GET'
+  };
+  debug('request %j', options);
+  request(options, function(err, res) {
+    t.ifError(err);
+    t.equal(res.statusCode, 404);
+    t.end();
+  });
+});
+
+// Test to attempt to delete a given collection that doesn't exist
+tap.test('DELETE deleted collection', function(t) {
+  const options = {
+    url: base + '/appmetrics/api/v1/collections/0',
+    method: 'DELETE'
+  };
+  debug('request %j', options);
+  request(options, function(err, res) {
+    t.ifError(err);
+    t.equal(res.statusCode, 404);
+    t.end();
+  });
+});
+
+// Test to GET all collections now that the first has been deleted
+tap.test('GET collections', function(t) {
+  const options = {
+    url: base + '/appmetrics/api/v1/collections',
+    method: 'GET'
+  };
+  debug('request %j', options);
+  request(options, function(err, res, body) {
+    t.ifError(err);
+    let expectedResponse = '{"collectionUris":["collections/1"]}';
+    t.equal(body, expectedResponse);
+    t.equal(res.statusCode, 200);
+    t.end();
+  });
+});
+
+tap.test('stop', function(t) {
+  server.close(t.end);
+});

--- a/test/test-env-route.js
+++ b/test/test-env-route.js
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright 2018 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+'use strict';
+
+const debug = require('debug')('profilingRoutes:test');
+const request = require('request');
+const tap = require('tap');
+const appmetrics = require('appmetrics');
+
+const createHttpServer = require('./apps/createHttpServer');
+
+// Setup appmetrics and start app somewhat as a supervisor would.
+appmetrics.start();
+require('..').attach({appmetrics: appmetrics});
+
+const server = createHttpServer();
+
+let serverOrigin;
+
+tap.test('start', function(t) {
+  server.on('listening', function() {
+    let { address, port } = this.address();
+    if (address === '0.0.0.0') {
+      address = '127.0.0.1';
+    } else if (address === '::') {
+      address = '[::1]';
+    }
+    serverOrigin = `http://${address}:${port}`;
+    t.pass('listened');
+    t.end();
+  });
+});
+
+tap.test('GET /metrics/environment returns ??', function(t) {
+  const options = {
+    method: 'GET',
+    url: `${serverOrigin}/metrics/environment`,
+  };
+  debug('request %j', options);
+  request(options, function(err, res, body) {
+    t.ifError(err);
+    t.equal(res.statusCode, 200);
+    t.equal(body, '');
+    // TODO: test with a timeout?
+    // const resBody = JSON.parse(body);
+    // t.type(resBody, 'object');
+    t.end();
+  });
+});
+
+tap.test('stop', function(t) {
+  server.close(t.end);
+});

--- a/test/test-https-injection.js
+++ b/test/test-https-injection.js
@@ -21,6 +21,8 @@ const request = require('request');
 const tap = require('tap');
 const util = require('util');
 
+const config = require('./config');
+
 // Setup appmetrics and start app somewhat as a supervisor would.
 const appmetrics = require('appmetrics');
 appmetrics.start();
@@ -67,7 +69,9 @@ tap.test('metrics available', function(t) {
   debug('request %j', req);
   request(req, function(err, resp, body) {
     t.ifError(err);
-    t.similar(body, /os_cpu_used_ratio/);
+    config.expectedMetrics.forEach(metricName => {
+      t.similar(body, metricName);
+    });
     t.end();
   });
 });

--- a/test/test-loopback-injection.js
+++ b/test/test-loopback-injection.js
@@ -20,6 +20,8 @@ const request = require('request');
 const tap = require('tap');
 const util = require('util');
 
+const config = require('./config');
+
 // Setup appmetrics and start app somewhat as a supervisor would.
 const appmetrics = require('appmetrics');
 appmetrics.start();
@@ -58,7 +60,9 @@ tap.test('metrics available', function(t) {
   };
   request(options, function(err, resp, body) {
     t.ifError(err);
-    t.similar(body, /os_cpu_used_ratio/);
+    config.expectedMetrics.forEach(metricName => {
+      t.similar(body, metricName);
+    });
     t.end();
   });
 });

--- a/test/test-profiling-routes.js
+++ b/test/test-profiling-routes.js
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright 2018 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+'use strict';
+
+const debug = require('debug')('profilingRoutes:test');
+const request = require('request');
+const tap = require('tap');
+const appmetrics = require('appmetrics');
+
+const createHttpServer = require('./apps/createHttpServer');
+
+// Setup appmetrics and start app somewhat as a supervisor would.
+appmetrics.start();
+require('..').attach({appmetrics: appmetrics});
+
+const server = createHttpServer();
+
+let serverOrigin;
+
+tap.test('start', function(t) {
+  server.on('listening', function() {
+    let { address, port } = this.address();
+    if (address === '0.0.0.0') {
+      address = '127.0.0.1';
+    } else if (address === '::') {
+      address = '[::1]';
+    }
+    serverOrigin = `http://${address}:${port}`;
+    t.pass('listened');
+    t.end();
+  });
+});
+
+tap.test('GET /metrics/profiling returns an array', function(t) {
+  const options = {
+    method: 'GET',
+    url: `${serverOrigin}/metrics/profiling`,
+  };
+  debug('request %j', options);
+  request(options, function(err, res, body) {
+    t.ifError(err);
+    t.equal(res.statusCode, 200);
+    t.equal(body, '[]');
+    // TODO: test with a timeout?
+    // const resBody = JSON.parse(body);
+    // t.type(resBody, 'object');
+    t.end();
+  });
+});
+
+tap.test('POST /metrics/profiling/on suceeeds', function(t) {
+  const options = {
+    method: 'POST',
+    url: `${serverOrigin}/metrics/profiling/on`,
+  };
+  debug('request %j', options);
+  request(options, function(err, res, body) {
+    t.ifError(err);
+    t.equal(res.statusCode, 200);
+    t.equal(body, 'Profiling enabled');
+    t.end();
+  });
+});
+
+tap.test('POST /metrics/profiling/off suceeeds', function(t) {
+  const options = {
+    method: 'POST',
+    url: `${serverOrigin}/metrics/profiling/off`,
+  };
+  debug('request %j', options);
+  request(options, function(err, res, body) {
+    t.ifError(err);
+    t.equal(res.statusCode, 200);
+    t.equal(body, 'Profiling disabled');
+    t.end();
+  });
+});
+
+tap.test('stop', function(t) {
+  server.close(t.end);
+});


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

**Summary:** Add metrics; Exposing profiling and environment data; Allow profiling to be enabled and disabled via HTTP

This is part of https://github.com/eclipse/codewind/issues/977.

Previously, appmetrics-prometheus exposed only a subset of metrics received from Appmetrics (over the socket connection). This was not enough metrics to populate `appmetrics-dash`. 

Eclipse Codewind wants to be able to scrape the project's metric data over HTTP, gathering enough metrics to populate `appmetrics-dash` (without needing any socket connection to the project). 

This PR therefore exposes all the metrics needed to populate `appmetrics-dash`, by:
1. exposing more Prometheus style metrics on the existing `/metrics` endpoint
2. exposing appmetrics profiling data on a new `/metrics/profiling` endpoint. Also, profiling can now be enabled and disabled via POST requests to `/metrics/profiling/on` and `/metrics/profiling/off` respectively.
3. exposing app environment data on a new `/metrics/environment` endpoint.

I have covered some of this with automated tests, though really our tests need to be modified to wait ~10 seconds for metrics data to come through. Right now we test the sample servers immediately, when only ~7 out of ~20 metrics are available.