### PR TITLE
Expose more metrics on endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node-report*
 node_modules
 package-lock.json
 resourceRegistry.log
+coverage

--- a/lib/appmetrics-prometheus.js
+++ b/lib/appmetrics-prometheus.js
@@ -29,12 +29,20 @@ var latestMemEvent = {
   physical: 0,
   virtual: 0
 };
-var aggregateHttpEvent;
+let latestLoopEvent;
+let latestGCEvent;
+let aggregateHttpEvent = {};
+let aggregateHttpsEvent = {};
+let aggregateHttpOutboundEvent = {};
+let aggregateHttpsOutboundEvent = {};
 var httpURLDataList = [];
 var save = {
   http: {},
   https: {},
 };
+// GC summary data
+let gcDurationTotal = 0.0;
+let maxHeapUsed = 0;
 
 
 exports.attach = function(options) {
@@ -123,24 +131,39 @@ function endpoint(options) {
   var appmetrics = (options || {}).appmetrics || require('appmetrics');
   var monitoring = appmetrics.monitor();
   function site(req, res) {
-    var cpuData = stringCPUData(latestCPUEvent);
-    var memoryData = stringMemoryData(latestMemEvent);
-    var httpRequestTotal = stringHttpRequestTotal(httpURLDataList);
-    var httpRequestDuration = stringHttpRequestDuration(httpURLDataList);
-    res.writeHead(200, {'Content-Type': 'text/plain'});
-    res.write(cpuData);
-    res.write(memoryData);
-
-    if (httpURLDataList.length > 0) {
-      res.write(httpRequestTotal);
-      res.write(httpRequestDuration);
-    }
-    res.end();
+    const data = [
+      stringCPUData(latestCPUEvent),
+      stringMemoryData(latestMemEvent),
+      stringHttpRequestsAlltimeTotal(httpURLDataList),
+      stringHttpRequestDuration(httpURLDataList),
+      stringProcessUptime(),
+      stringLoopData(latestLoopEvent),
+      stringGCData(latestGCEvent, maxHeapUsed, gcDurationTotal),
+      stringHttpRequestsTotal(aggregateHttpEvent),
+      stringHttpRequestsDurationAverage(aggregateHttpEvent),
+      stringHttpRequestsDurationMax(aggregateHttpEvent),
+      stringHttpsRequestsTotal(aggregateHttpsEvent),
+      stringHttpsRequestsDurationAverage(aggregateHttpsEvent),
+      stringHttpsRequestsDurationMax(aggregateHttpsEvent),
+      stringHttpOutboundRequestsTotal(aggregateHttpOutboundEvent),
+      stringHttpOutboundRequestsDurationAverage(aggregateHttpOutboundEvent),
+      stringHttpOutboundRequestsDurationMax(aggregateHttpOutboundEvent),
+      stringHttpsOutboundRequestsTotal(aggregateHttpsOutboundEvent),
+      stringHttpsOutboundRequestsDurationAverage(aggregateHttpsOutboundEvent),
+      stringHttpsOutboundRequestsDurationMax(aggregateHttpsOutboundEvent),
+      stringHttpRequestsAlltimeDurationAverage(httpURLDataList),
+      stringHttpRequestsAlltimeDurationMax(httpURLDataList),
+    ].filter(Boolean) // Filters out empty strings
+      .join('');
+    aggregateHttpEvent = {};
+    aggregateHttpsEvent = {};
+    aggregateHttpOutboundEvent = {};
+    aggregateHttpsOutboundEvent = {};
+    res.setHeader('content-type', 'text/plain');
+    res.send(data);
   }
 
-  /*
-   * Broadcast monitoring data to connected clients when it arrives
-   */
+
   monitoring.on('cpu', function(data) {
     latestCPUEvent = data;
   });
@@ -149,53 +172,22 @@ function endpoint(options) {
     latestMemEvent = data;
   });
 
-  monitoring.on('http', function(data) {
-    if (!aggregateHttpEvent) {
-      aggregateHttpEvent = {};
-      aggregateHttpEvent.total = 1;
-      aggregateHttpEvent.average = data.duration;
-      aggregateHttpEvent.longest = data.duration;
-      aggregateHttpEvent.time = data.time;
-      aggregateHttpEvent.handler = data.url;
-      aggregateHttpEvent.code = data.statusCode;
-      aggregateHttpEvent.method = data.method;
-    } else {
-      aggregateHttpEvent.total = aggregateHttpEvent.total + 1;
-      aggregateHttpEvent.average = (aggregateHttpEvent.average * (aggregateHttpEvent.total - 1) + data.duration) / aggregateHttpEvent.total;
-      if (data.duration > aggregateHttpEvent.longest) {
-        aggregateHttpEvent.longest = data.duration;
-        aggregateHttpEvent.url = data.url;
-      }
-    }
-
-    // See if httpURLDataList contains a json object which has already has the collected url and statusCode
-    var found = false;
-    var foundIndex;
-    var i = 0;
-    while (found === false && i < httpURLDataList.length) {
-      if (httpURLDataList[i].url == data.url && httpURLDataList[i].code == data.statusCode) {
-        found = true;
-        foundIndex = i;
-      }
-      i++;
-    }
-
-    // If found we increment the number of hits on the url
-    // Else add new json object to list with the 'hits' value of 1
-    if (found) {
-      var urlData = httpURLDataList[foundIndex];
-      // Recalculate the average
-      urlData.average_duration = (urlData.duration * urlData.hits + data.duration) / (urlData.hits + 1);
-      urlData.hits = urlData.hits + 1;
-      // Add new duration to the duration_list
-      urlData.duration_list.push(data.duration);
-      // Reorder duration_list so it is in ascending order
-      urlData.duration_list.sort(function(a, b){ return a - b; });
-    } else {
-      httpURLDataList.push({url: data.url, average_duration: data.duration, hits: 1, method: data.method, code: data.statusCode, duration_list: [data.duration]});
-    }
-
+  monitoring.on('loop', function(data) {
+    latestLoopEvent = data;
   });
+  monitoring.on('gc', function(data) {
+    latestGCEvent = data;
+    gcDurationTotal += data.duration;
+    maxHeapUsed = Math.max(maxHeapUsed, data.used);
+    latestGCEvent.timeSummary = (gcDurationTotal / (process.uptime() * 1000));
+    latestGCEvent.usedHeapAfterGCMax = maxHeapUsed;
+  });
+
+  monitoring.on('http', (data) => saveHttpOrHttpsData(data, aggregateHttpEvent, httpURLDataList));
+  monitoring.on('https', (data) => saveHttpOrHttpsData(data, aggregateHttpsEvent, httpURLDataList));
+  monitoring.on('http-outbound', (data) => updateAggregateEvent(aggregateHttpOutboundEvent, data));
+  monitoring.on('https-outbound', (data) => updateAggregateEvent(aggregateHttpsOutboundEvent, data));
+
   return site;
 }
 
@@ -237,21 +229,18 @@ function stringMemoryData(latestMemEvent) {
   return content;
 }
 
-function stringHttpRequestTotal(httpURLDataList) {
-  var content = '';
-  content += '# HELP http_requests_total Total number of HTTP requests made.\n';
-  content += '# TYPE http_requests_total counter\n';
-  // Loop through httpURLDataList to display the appmetrics_http_requests_total
-  for (var i = 0; i < httpURLDataList.length; i++) {
-    var data = httpURLDataList[i];
-    // Convert the method to lowercase as per Prometheus guidelines (Appmetrics gives us method in uppercase)
-    var lowerCaseMethod = data.method.toLowerCase();
-    content += 'http_requests_total{code="' + data.code + '", handler="' + data.url +
-      '", method="' + lowerCaseMethod + '"} ' + data.hits + '\n';
-  }
-  return content;
+function stringHttpRequestsAlltimeTotal(httpURLDataList) {
+  if (!httpURLDataList.length) return;
+  return [
+    // i.e. Total number of HTTP requests received by this app since it started
+    '# HELP http_requests_total Total number of HTTP requests made.',
+    '# TYPE http_requests_total counter',
+    ...httpURLDataList.map(data =>
+      `http_requests_total{code="${data.code}", handler="${data.url}", method="${data.method.toLowerCase()}"} ${data.hits}`
+    ),
+    '',
+  ].join('\n');
 }
-
 function stringHttpRequestDuration(httpURLDataList) {
   var content = '';
   content += '# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.\n';
@@ -271,6 +260,267 @@ function stringHttpRequestDuration(httpURLDataList) {
     content += 'http_request_duration_microseconds_count{handler="' + data.url + '"} ' + countDurations + '\n';
   }
   return content;
+}
+
+function stringProcessUptime() {
+  return [
+    '# HELP process_uptime_count_seconds The number of seconds for which the current Node.js process has been running',
+    '# TYPE process_uptime_count_seconds counter',
+    `process_uptime_count_seconds ${process.uptime()}\n`,
+  ];
+}
+
+function stringLoopData(latestLoopEvent) {
+  if (!latestLoopEvent) return;
+  return [
+    '# HELP event_loop_tick_min_milliseconds The shortest tick time in the event loop samples, in milliseconds',
+    '# TYPE event_loop_tick_min_milliseconds guage',
+    `event_loop_tick_min_milliseconds ${latestLoopEvent.minimum}`,
+
+    '# HELP event_loop_tick_max_milliseconds The longest tick time in the event loop samples, in milliseconds',
+    '# TYPE event_loop_tick_max_milliseconds guage',
+    `event_loop_tick_max_milliseconds ${latestLoopEvent.maximum}`,
+
+    '# HELP event_loop_tick_count The number of event loop ticks in the last interval',
+    '# TYPE event_loop_tick_count counter',
+    `event_loop_tick_count ${latestLoopEvent.count}`,
+
+    '# HELP event_loop_tick_average_milliseconds The average tick time in the event loop samples, in milliseconds',
+    '# TYPE event_loop_tick_average_milliseconds guage',
+    `event_loop_tick_average_milliseconds ${latestLoopEvent.average}`,
+
+    '# HELP event_loop_cpu_user The percentage of 1 CPU used by the event loop thread in user code the last interval. This is a value between 0.0 and 1.0.',
+    '# TYPE event_loop_cpu_user guage',
+    `event_loop_cpu_user ${latestLoopEvent.cpu_user}`,
+
+    '# HELP event_loop_cpu_system The percentage of 1 CPU used by the event loop thread in system code in the last interval. This is a value between 0.0 and 1.0.',
+    '# TYPE event_loop_cpu_system guage',
+    `event_loop_cpu_system ${latestLoopEvent.cpu_system}\n`,
+  ].join('\n');
+}
+
+function stringGCData(latestGCEvent, maxHeapUsed, gcDurationTotal) {
+  if (!latestGCEvent) return;
+  return [
+    '# HELP heap_size_bytes The size of the JavaScript heap in bytes',
+    '# TYPE heap_size_bytes guage',
+    `heap_size_bytes ${latestGCEvent.size}`,
+
+    '# HELP heap_memory_used_bytes The amount of memory used on the JavaScript heap in bytes',
+    '# TYPE heap_memory_used_bytes guage',
+    `heap_memory_used_bytes ${latestGCEvent.used}`,
+
+    '# HELP heap_memory_used_max_bytes The maximum amount of memory used on the JavaScript heap in bytes',
+    '# TYPE heap_memory_used_max_bytes count',
+    `heap_memory_used_max_bytes ${maxHeapUsed}`,
+
+    '# HELP gc_cycle_duration_milliseconds The duration of the GC cycle in milliseconds',
+    '# TYPE gc_cycle_duration_milliseconds guage',
+    `gc_cycle_duration_milliseconds ${latestGCEvent.duration}`,
+
+    '# HELP gc_cycle_duration_total_milliseconds The total duration of all GC cycles in milliseconds',
+    '# TYPE gc_cycle_duration_total_milliseconds count',
+    `gc_cycle_duration_total_milliseconds ${gcDurationTotal}\n`,
+  ].join('\n');
+}
+
+function stringHttpRequestsTotal(aggregateHttpEvent) {
+  if (isEmptyObject(aggregateHttpEvent)) return;
+  return [
+    '# HELP http_requests_snapshot_total Total number of HTTP requests received in this snapshot.',
+    '# TYPE http_requests_snapshot_total guage',
+    `http_requests_snapshot_total ${aggregateHttpEvent.total}\n`,
+  ].join('\n');
+}
+
+function stringHttpRequestsDurationAverage(aggregateHttpEvent) {
+  if (isEmptyObject(aggregateHttpEvent)) return;
+  return [
+    '# HELP http_requests_duration_average_microseconds Average duration of HTTP requests received in this snapshot.',
+    '# TYPE http_requests_duration_average_microseconds guage',
+    `http_requests_duration_average_microseconds ${aggregateHttpEvent.average}\n`,
+  ].join('\n');
+}
+
+function stringHttpRequestsDurationMax(aggregateHttpEvent) {
+  if (isEmptyObject(aggregateHttpEvent)) return;
+  return [
+    '# HELP http_requests_duration_max_microseconds Longest HTTP request received in this snapshot.',
+    '# TYPE http_requests_duration_max_microseconds guage',
+    `http_requests_duration_max_microseconds{handler="${aggregateHttpEvent.url}"} ${aggregateHttpEvent.longest}\n`,
+  ].join('\n');
+}
+
+function stringHttpsRequestsTotal(aggregateHttpsEvent) {
+  if (isEmptyObject(aggregateHttpsEvent)) return;
+  return [
+    '# HELP https_requests_total Total number of HTTPS requests received in this snapshot.',
+    '# TYPE https_requests_total guage',
+    `https_requests_total ${aggregateHttpsEvent.total}\n`,
+  ].join('\n');
+}
+
+function stringHttpsRequestsDurationAverage(aggregateHttpsEvent) {
+  if (isEmptyObject(aggregateHttpsEvent)) return;
+  return [
+    '# HELP https_requests_duration_average_microseconds Average duration of HTTPS requests received in this snapshot.',
+    '# TYPE https_requests_duration_average_microseconds guage',
+    `https_requests_duration_average_microseconds ${aggregateHttpsEvent.average}\n`,
+  ].join('\n');
+}
+
+function stringHttpsRequestsDurationMax(aggregateHttpsEvent) {
+  if (isEmptyObject(aggregateHttpsEvent)) return;
+  return [
+    '# HELP https_requests_duration_max_microseconds Longest HTTPS request received in this snapshot.',
+    '# TYPE https_requests_duration_max_microseconds guage',
+    `https_requests_duration_max_microseconds{handler="${aggregateHttpsEvent.url}"} ${aggregateHttpsEvent.longest}\n`,
+  ].join('\n');
+}
+
+function stringHttpOutboundRequestsTotal(aggregateHttpOutboundEvent) {
+  if (isEmptyObject(aggregateHttpOutboundEvent)) return;
+  return [
+    '# HELP http_outbound_requests_total Total number of HTTP requests sent during this snapshot.',
+    '# TYPE http_outbound_requests_total guage',
+    `http_outbound_requests_total ${aggregateHttpOutboundEvent.total}\n`,
+  ].join('\n');
+}
+
+function stringHttpOutboundRequestsDurationAverage(aggregateHttpOutboundEvent) {
+  if (isEmptyObject(aggregateHttpOutboundEvent)) return;
+  return [
+    '# HELP http_outbound_requests_duration_average_microseconds Average duration of HTTP requests sent during this snapshot.',
+    '# TYPE http_outbound_requests_duration_average_microseconds guage',
+    `http_outbound_requests_duration_average_microseconds ${aggregateHttpOutboundEvent.average}\n`,
+  ].join('\n');
+}
+
+function stringHttpOutboundRequestsDurationMax(aggregateHttpOutboundEvent) {
+  if (isEmptyObject(aggregateHttpOutboundEvent)) return;
+  return [
+    '# HELP http_outbound_requests_duration_max_microseconds Longest HTTP request sent during this snapshot.',
+    '# TYPE http_outbound_requests_duration_max_microseconds guage',
+    `http_outbound_requests_duration_max_microseconds{url="${aggregateHttpOutboundEvent.url}"} ${aggregateHttpOutboundEvent.longest}\n`,
+  ].join('\n');
+}
+
+function stringHttpsOutboundRequestsTotal(aggregateHttpsOutboundEvent) {
+  if (isEmptyObject(aggregateHttpsOutboundEvent)) return;
+  return [
+    '# HELP https_outbound_requests_total Total number of HTTPS requests sent during this snapshot.',
+    '# TYPE https_outbound_requests_total guage',
+    `https_outbound_requests_total ${aggregateHttpsOutboundEvent.total}\n`,
+  ].join('\n');
+}
+
+function stringHttpsOutboundRequestsDurationAverage(aggregateHttpsOutboundEvent) {
+  if (isEmptyObject(aggregateHttpsOutboundEvent)) return;
+  return [
+    '# HELP https_outbound_requests_duration_average_microseconds Average duration of HTTPS requests sent during this snapshot.',
+    '# TYPE https_outbound_requests_duration_average_microseconds guage',
+    `https_outbound_requests_duration_average_microseconds ${aggregateHttpsOutboundEvent.average}\n`,
+  ].join('\n');
+}
+
+function stringHttpsOutboundRequestsDurationMax(aggregateHttpsOutboundEvent) {
+  if (isEmptyObject(aggregateHttpsOutboundEvent)) return;
+  return [
+    '# HELP https_outbound_requests_duration_max_microseconds Longest HTTPS request sent during this snapshot.',
+    '# TYPE https_outbound_requests_duration_max_microseconds guage',
+    `https_outbound_requests_duration_max_microseconds{url="${aggregateHttpsOutboundEvent.url}"} ${aggregateHttpsOutboundEvent.longest}\n`,
+    '',
+  ].join('\n');
+}
+
+function stringHttpRequestsAlltimeDurationAverage(httpURLDataList) {
+  if (!httpURLDataList.length) return;
+  return [
+    '# HELP http_requests_alltime_duration_average_microseconds Average duration of HTTP requests received since app started.',
+    '# TYPE http_requests_alltime_duration_average_microseconds guage',
+    ...httpURLDataList.map(data =>
+      `http_requests_alltime_duration_average_microseconds{handler="${data.url}",method="${data.method.toLowerCase()}"} ${data.average_duration}`
+    ),
+    '',
+  ].join('\n');
+}
+
+function stringHttpRequestsAlltimeDurationMax(httpURLDataList) {
+  if (!httpURLDataList.length) return;
+  return [
+    '# HELP http_requests_alltime_duration_max_microseconds Average duration of HTTP requests received since app started.',
+    '# TYPE http_requests_alltime_duration_max_microseconds guage',
+    ...httpURLDataList.map(data =>
+      `http_requests_alltime_duration_max_microseconds{handler="${data.url}",method="${data.method.toLowerCase()}"} ${data.longest_duration}`
+    ),
+    '',
+  ].join('\n');
+}
+
+function saveHttpOrHttpsData(data, aggregateEvent, httpURLDataList) {
+  updateAggregateEvent(aggregateEvent, data);
+  updateHttpURLDataList(httpURLDataList, data);
+}
+
+function updateAggregateEvent(event, data) {
+  if (isEmptyObject(event)) {
+    event.total = 1;
+    event.average = data.duration;
+    event.longest = data.duration;
+    event.time = data.time;
+    event.url = data.url;
+    event.code = data.statusCode;
+    event.method = data.method;
+  } else {
+    event.total = event.total + 1;
+    event.average = (event.average * (event.total - 1) + data.duration) / event.total;
+    if (data.duration > event.longest) {
+      event.longest = data.duration;
+      event.url = data.url;
+    }
+  }
+}
+
+function updateHttpURLDataList(URLDataList, data) {
+  // See if httpURLDataList contains a json object which has already has the collected url and statusCode
+  var found = false;
+  var foundIndex;
+  var i = 0;
+  while (found === false && i < URLDataList.length) {
+    if (URLDataList[i].url == data.url && URLDataList[i].code == data.statusCode) {
+      found = true;
+      foundIndex = i;
+    }
+    i++;
+  }
+
+  // If found we increment the number of hits on the url
+  // Else add new json object to URLDataList with the 'hits' value of 1
+  if (found) {
+    var urlData = URLDataList[foundIndex];
+    // Recalculate the average
+    urlData.average_duration = (urlData.average_duration * urlData.hits + data.duration) / (urlData.hits + 1);
+    urlData.hits = urlData.hits + 1;
+    // Add new duration to the duration_list
+    urlData.duration_list.push(data.duration);
+    urlData.longest_duration = Math.max(...urlData.duration_list);
+    // Reorder duration_list so it is in ascending order
+    urlData.duration_list.sort(function(a, b){ return a - b; });
+  } else {
+    URLDataList.push({
+      url: data.url,
+      average_duration: data.duration,
+      longest_duration: data.duration,
+      hits: 1,
+      method: data.method,
+      code: data.statusCode,
+      duration_list: [data.duration]
+    });
+  }
+}
+
+function isEmptyObject(obj) {
+  return !Object.keys(obj).length;
 }
 
 function findQuantile(list, quantile) {

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright 2017 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+'use strict';
+
+const expectedMetrics = [
+  'os_cpu_used_ratio',
+  'process_cpu_used_ratio',
+  'os_resident_memory_bytes',
+  'process_resident_memory_bytes',
+  'process_virtual_memory_bytes',
+  'http_request_duration_microseconds',
+  'process_uptime_count_seconds',
+  // Other metrics not immediately available:
+  // 'http_requests_total',
+  // 'event_loop_tick_min_milliseconds',
+  // 'event_loop_tick_max_milliseconds',
+  // 'event_loop_tick_average_milliseconds',
+  // 'event_loop_cpu_user',
+  // 'event_loop_cpu_system',
+  // 'heap_size_bytes',
+  // 'heap_memory_used_bytes',
+  // 'heap_memory_used_max_bytes',
+  // 'gc_cycle_duration_milliseconds',
+  // 'gc_cycle_duration_total_milliseconds',
+  // 'http_requests_snapshot_total',
+  // 'http_requests_duration_average_microseconds',
+  // 'http_requests_duration_max_microseconds',
+  // 'http_requests_alltime_duration_average_microseconds',
+];
+
+module.exports = {
+  expectedMetrics,
+};

--- a/test/test-http-inject-recursion.js
+++ b/test/test-http-inject-recursion.js
@@ -21,6 +21,7 @@ const request = require('request');
 const tap = require('tap');
 const util = require('util');
 
+const config = require('./config');
 // Setup appmetrics and start app somewhat as a supervisor would.
 const appmetrics = require('appmetrics');
 appmetrics.start();
@@ -62,7 +63,9 @@ tap.test('metrics available', function(t) {
   debug('request %j', options);
   request(options, function(err, resp, body) {
     t.ifError(err);
-    t.similar(body, /os_cpu_used_ratio/);
+    config.expectedMetrics.forEach(metricName => {
+      t.similar(body, metricName);
+    });
     t.end();
   });
 });

--- a/test/test-https-injection.js
+++ b/test/test-https-injection.js
@@ -21,6 +21,8 @@ const request = require('request');
 const tap = require('tap');
 const util = require('util');
 
+const config = require('./config');
+
 // Setup appmetrics and start app somewhat as a supervisor would.
 const appmetrics = require('appmetrics');
 appmetrics.start();
@@ -67,7 +69,9 @@ tap.test('metrics available', function(t) {
   debug('request %j', req);
   request(req, function(err, resp, body) {
     t.ifError(err);
-    t.similar(body, /os_cpu_used_ratio/);
+    config.expectedMetrics.forEach(metricName => {
+      t.similar(body, metricName);
+    });
     t.end();
   });
 });

--- a/test/test-loopback-injection.js
+++ b/test/test-loopback-injection.js
@@ -20,6 +20,8 @@ const request = require('request');
 const tap = require('tap');
 const util = require('util');
 
+const config = require('./config');
+
 // Setup appmetrics and start app somewhat as a supervisor would.
 const appmetrics = require('appmetrics');
 appmetrics.start();
@@ -58,7 +60,9 @@ tap.test('metrics available', function(t) {
   };
   request(options, function(err, resp, body) {
     t.ifError(err);
-    t.similar(body, /os_cpu_used_ratio/);
+    config.expectedMetrics.forEach(metricName => {
+      t.similar(body, metricName);
+    });
     t.end();
   });
 });


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

Previously, appmetrics-prometheus exposed only a subset of metrics received from Appmetrics (over the socket connection). This was not enough metrics to populate `appmetrics-dash`. 

Eclipse Codewind is an example of a project wanting to be able to scrape (over HTTP) enough of the project's metric data to populate `appmetrics-dash` without needing a direct socket connection to the project (see https://github.com/eclipse/codewind/issues/977).

I have done my best to follow [Prometheus's guidelines](https://prometheus.io/docs/instrumenting/writing_exporters/) but please review carefully. There are metrics that I'm not happy with but I can't think of a better way to expose the metrics needed to populate `appmetrics-dash`. 

I have covered this with automated tests to a similar level that was already existing in this project. I believe that we could and should do better by modifying our tests to wait ~10 seconds for metrics data to come through. (Right now we test the sample servers immediately, when only ~7 out of ~20 metrics are available). I leave that for the maintainers to decide.

I would also like to raise a PR after this cleaning the legacy code up (even simple things such as `var` -> `const`). I have not included the cleaning in this PR, to minimise diff and so maximise clarity to reviewers
